### PR TITLE
Support more constant types

### DIFF
--- a/src/main/java/daomephsta/unpick/impl/AbstractInsnNodes.java
+++ b/src/main/java/daomephsta/unpick/impl/AbstractInsnNodes.java
@@ -58,9 +58,25 @@ public class AbstractInsnNodes
 			Character charLiteral = (char) (int) literalValue;
 			return literal.equals(charLiteral);
 		}
-		// Compare numbers by long value, to support widening comparisons
-		if (literalValue instanceof Number && literal instanceof Number)
+		// Compare integers by long value, to support widening comparisons
+		if (isIntegral(literalValue) && isIntegral(literal))
 		    return ((Number) literalValue).longValue() == ((Number) literal).longValue();
+		// Compare floating point numbers by double value, to support widening comparisons
+		if (isFloatingPoint(literalValue) && isFloatingPoint(literal))
+		    return ((Number) literalValue).doubleValue() == ((Number) literal).doubleValue();
 		return literalValue.equals(literal);
+	}
+	
+	private static boolean isIntegral(Object literal)
+	{
+		return literal instanceof Byte || 
+			   literal instanceof Short || 
+			   literal instanceof Integer || 
+			   literal instanceof Long;
+	}
+	
+	private static boolean isFloatingPoint(Object literal)
+	{
+		return literal instanceof Float || literal instanceof Double;
 	}
 }

--- a/src/main/java/daomephsta/unpick/impl/AbstractInsnNodes.java
+++ b/src/main/java/daomephsta/unpick/impl/AbstractInsnNodes.java
@@ -51,6 +51,16 @@ public class AbstractInsnNodes
 	
 	public static boolean isLiteral(AbstractInsnNode insn, Object literal)
 	{
-		return getLiteralValue(insn).equals(literal);
+		Object literalValue = getLiteralValue(insn);
+		// Chars are stored as ints, so conversion is necessary
+		if (literal instanceof Character && literalValue instanceof Integer)
+		{
+			Character charLiteral = (char) (int) literalValue;
+			return literal.equals(charLiteral);
+		}
+		// Compare numbers by long value, to support widening comparisons
+		if (literalValue instanceof Number && literal instanceof Number)
+		    return ((Number) literalValue).longValue() == ((Number) literal).longValue();
+		return literalValue.equals(literal);
 	}
 }

--- a/src/main/java/daomephsta/unpick/impl/InstructionFactory.java
+++ b/src/main/java/daomephsta/unpick/impl/InstructionFactory.java
@@ -19,9 +19,11 @@ public class InstructionFactory
 				return pushesDouble(number.doubleValue());
 			else if (number instanceof Float)
 				return pushesFloat(number.floatValue());
-			else //Shorts, bytes, and chars are all ints internally
+			else //Shorts and bytes are all ints internally
 				return pushesInt(number.intValue());
 		}
+		else if (value instanceof Character)
+			return pushesChar((char) value);
 		else if (value instanceof Boolean)
 			return pushesBoolean((boolean) value);
 		else if (value instanceof String)
@@ -43,9 +45,11 @@ public class InstructionFactory
 				pushesDouble(method, number.doubleValue());
 			else if (number instanceof Float)
 				pushesFloat(method, number.floatValue());
-			else //Shorts, bytes, and chars are all ints internally
+			else //Shorts and bytes are all ints internally
 				pushesInt(method, number.intValue());
 		}
+		else if (value instanceof Character)
+			pushesChar(method, (char) value);
 		else if (value instanceof Boolean)
 			pushesBoolean(method, (boolean) value);
 		else if (value instanceof String)
@@ -64,6 +68,16 @@ public class InstructionFactory
 	public static void pushesBoolean(MethodVisitor method, boolean bool)
 	{
 		method.visitInsn(bool ? ICONST_1 : ICONST_0);
+	}
+	
+	public static AbstractInsnNode pushesChar(char c)
+	{
+		return pushesInt(c);
+	}
+	
+	public static void pushesChar(MethodVisitor method, char c)
+	{
+		pushesInt(method, c);
 	}
 	
 	private static final int[] I_OPCODES = {ICONST_0, ICONST_1, ICONST_2, ICONST_3, ICONST_4, ICONST_5}; 

--- a/src/main/java/daomephsta/unpick/impl/IntegerType.java
+++ b/src/main/java/daomephsta/unpick/impl/IntegerType.java
@@ -26,11 +26,11 @@ public enum IntegerType
 
 		@Override
 		public Number binaryNegate(Number value)
-			{ return ~value.intValue(); }
+			{ return ~value.byteValue(); }
 
 		@Override
 		public long toUnsignedLong(Number value)
-			{ return Integer.toUnsignedLong(value.intValue()); }
+			{ return Byte.toUnsignedLong(value.byteValue()); }
 	},
 	SHORT(Short.class, short.class, Type.SHORT_TYPE, Opcodes.IAND, Opcodes.IRETURN) 
 	{
@@ -48,11 +48,11 @@ public enum IntegerType
 
 		@Override
 		public Number binaryNegate(Number value)
-			{ return ~value.intValue(); }
+			{ return ~value.shortValue(); }
 
 		@Override
 		public long toUnsignedLong(Number value)
-			{ return Integer.toUnsignedLong(value.intValue()); }
+			{ return Short.toUnsignedLong(value.shortValue()); }
 	},
 	INT(Integer.class, int.class, Type.INT_TYPE, Opcodes.IAND, Opcodes.IRETURN) 
 	{
@@ -66,7 +66,7 @@ public enum IntegerType
 		
 		@Override
 		public Number box(long value)
-			{ return new Integer((int) value); }
+			{ return Integer.valueOf((int) value); }
 
 		@Override
 		public Number binaryNegate(Number value)
@@ -88,7 +88,7 @@ public enum IntegerType
 		
 		@Override
 		public Number box(long value)
-			{ return new Long(value); }
+			{ return Long.valueOf(value); }
 
 		@Override
 		public Number binaryNegate(Number value)

--- a/src/main/java/daomephsta/unpick/impl/IntegerType.java
+++ b/src/main/java/daomephsta/unpick/impl/IntegerType.java
@@ -26,7 +26,7 @@ public enum IntegerType
 
 		@Override
 		public Number binaryNegate(Number value)
-			{ return ~value.byteValue(); }
+			{ return (byte) ~value.byteValue(); }
 
 		@Override
 		public long toUnsignedLong(Number value)
@@ -52,7 +52,7 @@ public enum IntegerType
 
 		@Override
 		public Number binaryNegate(Number value)
-			{ return ~value.shortValue(); }
+			{ return (short) ~value.shortValue(); }
 
 		@Override
 		public long toUnsignedLong(Number value)

--- a/src/main/java/daomephsta/unpick/impl/IntegerType.java
+++ b/src/main/java/daomephsta/unpick/impl/IntegerType.java
@@ -31,6 +31,10 @@ public enum IntegerType
 		@Override
 		public long toUnsignedLong(Number value)
 			{ return Byte.toUnsignedLong(value.byteValue()); }
+
+		@Override
+		public Number parse(String valueString)
+			{ return Byte.parseByte(valueString); }
 	},
 	SHORT(Short.class, short.class, Type.SHORT_TYPE, Opcodes.IAND, Opcodes.IRETURN) 
 	{
@@ -53,6 +57,10 @@ public enum IntegerType
 		@Override
 		public long toUnsignedLong(Number value)
 			{ return Short.toUnsignedLong(value.shortValue()); }
+
+		@Override
+		public Number parse(String valueString)
+			{ return Short.parseShort(valueString); }
 	},
 	INT(Integer.class, int.class, Type.INT_TYPE, Opcodes.IAND, Opcodes.IRETURN) 
 	{
@@ -75,6 +83,10 @@ public enum IntegerType
 		@Override
 		public long toUnsignedLong(Number value)
 			{ return Integer.toUnsignedLong(value.intValue()); }
+		
+		@Override
+		public Number parse(String valueString)
+			{ return Integer.parseInt(valueString); }
 	},
 	LONG(Long.class, long.class, Type.LONG_TYPE, Opcodes.LAND, Opcodes.LRETURN) 
 	{
@@ -97,6 +109,10 @@ public enum IntegerType
 		@Override
 		public long toUnsignedLong(Number value)
 			{ return value.longValue(); }
+		
+		@Override
+		public Number parse(String valueString)
+			{ return Long.parseLong(valueString); }
 	};
 	
 	private final Class<? extends Number> boxed, primitive;
@@ -112,14 +128,24 @@ public enum IntegerType
 		this.returnOpcode = returnOpcode;
 	}
 	
-	public static IntegerType from(Class<?> clazz)
+	public static IntegerType from(Type type)
+	{ 
+		for (IntegerType intType : values())
+		{
+			if (intType.type == type)
+				return intType;
+		}
+		throw new IllegalArgumentException(type + " is not one of: " + describeValidTypes());
+	}
+	
+	public static IntegerType from(Object literal)
 	{ 
 		for (IntegerType type : values())
 		{
-			if (clazz == type.getBoxClass() || clazz == type.getPrimitiveClass())
+			if (literal.getClass() == type.getBoxClass() || literal.getClass() == type.getPrimitiveClass())
 				return type;
 		}
-		throw new IllegalArgumentException(clazz + " is not one of: " + describeValidTypes());
+		throw new IllegalArgumentException(literal + " is not one of: " + describeValidTypes());
 	}
 
 	private static String describeValidTypes()
@@ -213,4 +239,6 @@ public enum IntegerType
 	public abstract Number binaryNegate(Number value);
 
 	public abstract long toUnsignedLong(Number value);
+	
+	public abstract Number parse(String valueString);
 }

--- a/src/main/java/daomephsta/unpick/impl/LiteralType.java
+++ b/src/main/java/daomephsta/unpick/impl/LiteralType.java
@@ -1,7 +1,10 @@
 package daomephsta.unpick.impl;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.objectweb.asm.*;
 import org.objectweb.asm.tree.AbstractInsnNode;
@@ -9,6 +12,52 @@ import org.objectweb.asm.tree.InsnNode;
 
 public enum LiteralType
 {
+	BYTE(Byte.class, byte.class, Type.BYTE_TYPE, Opcodes.IRETURN)
+	{
+		@Override
+		public AbstractInsnNode createLiteralPushInsn(Object literal)
+			{ return InstructionFactory.pushesInt(((Number) literal).intValue()); }
+
+		@Override
+		public void appendLiteralPushInsn(MethodVisitor mv, Object literal)
+			{ InstructionFactory.pushesInt(mv, ((Number) literal).intValue()); }
+
+		@Override
+		public Object parse(String valueString)
+			{ return Byte.parseByte(valueString); }
+	},
+	SHORT(Short.class, short.class, Type.SHORT_TYPE, Opcodes.IRETURN)
+	{
+		@Override
+		public AbstractInsnNode createLiteralPushInsn(Object literal)
+			{ return InstructionFactory.pushesInt(((Number) literal).intValue()); }
+
+		@Override
+		public void appendLiteralPushInsn(MethodVisitor mv, Object literal)
+			{ InstructionFactory.pushesInt(mv, ((Number) literal).intValue()); }
+
+		@Override
+		public Object parse(String valueString)
+			{ return Short.parseShort(valueString); }
+	},
+	CHAR(Character.class, char.class, Type.CHAR_TYPE, Opcodes.IRETURN)
+	{
+		@Override
+		public AbstractInsnNode createLiteralPushInsn(Object literal)
+			{ return InstructionFactory.pushesChar((char) literal); }
+
+		@Override
+		public void appendLiteralPushInsn(MethodVisitor mv, Object literal)
+			{ InstructionFactory.pushesChar(mv, (char) literal); }
+
+		@Override
+		public Object parse(String valueString)	
+		{ 
+			if (valueString.length() != 1)
+				throw new IllegalArgumentException(valueString + " is not a single character");
+			return valueString.charAt(0);
+		}
+	},
 	INT(Integer.class, int.class, Type.INT_TYPE, Opcodes.IRETURN) 
 	{
 		@Override
@@ -123,7 +172,7 @@ public enum LiteralType
 		if (valuesByClass.containsKey(clazz))
 			return valuesByClass.get(clazz);
 		else
-			throw new IllegalArgumentException(clazz + " is not an int, long, float, double, String, or type reference");
+			throw new IllegalArgumentException(clazz + " is not one of: " + describeValidTypes());
 	}
 	
 	public static LiteralType from(Type type)
@@ -131,7 +180,14 @@ public enum LiteralType
 		if (valuesByType.containsKey(type))
 			return valuesByType.get(type);
 		else 
-			throw new IllegalArgumentException(type + " is not an int, float, long, double, String, or type reference");
+			throw new IllegalArgumentException(type + " is not one of: " + describeValidTypes());
+	}
+
+	private static String describeValidTypes()
+	{
+		return Arrays.stream(values())
+			.map(t -> t.name().toLowerCase(Locale.ROOT).replace('_', ' '))
+			.collect(Collectors.joining(", "));
 	}
 	
 	public AbstractInsnNode createReturnInsn()

--- a/src/main/java/daomephsta/unpick/impl/LiteralType.java
+++ b/src/main/java/daomephsta/unpick/impl/LiteralType.java
@@ -16,11 +16,11 @@ public enum LiteralType
 	{
 		@Override
 		public AbstractInsnNode createLiteralPushInsn(Object literal)
-			{ return InstructionFactory.pushesInt(((Number) literal).intValue()); }
+			{ return InstructionFactory.pushesInt(((Number) literal).byteValue()); }
 
 		@Override
 		public void appendLiteralPushInsn(MethodVisitor mv, Object literal)
-			{ InstructionFactory.pushesInt(mv, ((Number) literal).intValue()); }
+			{ InstructionFactory.pushesInt(mv, ((Number) literal).byteValue()); }
 
 		@Override
 		public Object parse(String valueString)
@@ -30,11 +30,11 @@ public enum LiteralType
 	{
 		@Override
 		public AbstractInsnNode createLiteralPushInsn(Object literal)
-			{ return InstructionFactory.pushesInt(((Number) literal).intValue()); }
+			{ return InstructionFactory.pushesInt(((Number) literal).shortValue()); }
 
 		@Override
 		public void appendLiteralPushInsn(MethodVisitor mv, Object literal)
-			{ InstructionFactory.pushesInt(mv, ((Number) literal).intValue()); }
+			{ InstructionFactory.pushesInt(mv, ((Number) literal).shortValue()); }
 
 		@Override
 		public Object parse(String valueString)

--- a/src/main/java/daomephsta/unpick/impl/LiteralType.java
+++ b/src/main/java/daomephsta/unpick/impl/LiteralType.java
@@ -4,6 +4,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.objectweb.asm.*;
@@ -53,8 +55,13 @@ public enum LiteralType
 		@Override
 		public Object parse(String valueString)	
 		{ 
+			// Unicode escape parsing
+			Matcher m = UNICODE_ESCAPE.matcher(valueString);
+			if (m.matches())
+				return (char) Integer.parseInt(m.group(1), 16);
+			// Plain java char parsing
 			if (valueString.length() != 1)
-				throw new IllegalArgumentException(valueString + " is not a single character");
+				throw new IllegalArgumentException(valueString + " is not a single character or valid unicode escape");
 			return valueString.charAt(0);
 		}
 	},
@@ -143,6 +150,7 @@ public enum LiteralType
 			{ return Type.getType(valueString); }
 	};
 	
+	private static final Pattern UNICODE_ESCAPE = Pattern.compile("\\\\u+([0-9a-fA-F]{1,4})");
 	private static final Map<Class<?>, LiteralType> valuesByClass = new HashMap<>();
 	private static final Map<Type, LiteralType> valuesByType = new HashMap<>();
 	static

--- a/src/main/java/daomephsta/unpick/impl/representations/AbstractConstantDefinition.java
+++ b/src/main/java/daomephsta/unpick/impl/representations/AbstractConstantDefinition.java
@@ -124,5 +124,10 @@ public abstract class AbstractConstantDefinition<C extends AbstractConstantDefin
 		{
 			super(message);
 		}
+
+		public ResolutionException(String message, Throwable cause)
+		{
+			super(message, cause);
+		}
 	}
 }

--- a/src/main/java/daomephsta/unpick/impl/representations/FlagConstantGroup.java
+++ b/src/main/java/daomephsta/unpick/impl/representations/FlagConstantGroup.java
@@ -50,7 +50,7 @@ public class FlagConstantGroup extends AbstractConstantGroup<FlagDefinition>
 	public void generateReplacements(Context context)
 	{
 		Number literalNum = (Number) AbstractInsnNodes.getLiteralValue(context.getArgSeed());
-		IntegerType integerType = IntegerType.from(literalNum.getClass());
+		IntegerType integerType = IntegerType.from(literalNum);
 
 		resolveAllConstants(context.getConstantResolver());
 

--- a/src/main/java/daomephsta/unpick/impl/representations/FlagDefinition.java
+++ b/src/main/java/daomephsta/unpick/impl/representations/FlagDefinition.java
@@ -3,6 +3,7 @@ package daomephsta.unpick.impl.representations;
 import org.objectweb.asm.Type;
 
 import daomephsta.unpick.constantmappers.datadriven.parser.UnpickSyntaxException;
+import daomephsta.unpick.impl.IntegerType;
 
 /**
  * Represents a flag field. The value and descriptor may be
@@ -42,11 +43,7 @@ public class FlagDefinition extends AbstractConstantDefinition<FlagDefinition>
 	{
 		try 
 		{ 
-			if (descriptor == Type.INT_TYPE)
-				return Integer.parseInt(valueString);
-			else if (descriptor == Type.LONG_TYPE)
-				return Long.parseLong(valueString); 
-			else throw new UnpickSyntaxException("Cannot parse value " + valueString + " with descriptor " + descriptor);
+			return IntegerType.from(descriptor).parse(valueString);
 		}
 		catch (IllegalArgumentException e) 
 		{
@@ -57,10 +54,16 @@ public class FlagDefinition extends AbstractConstantDefinition<FlagDefinition>
 	@Override
 	protected void setValue(Object value) throws ResolutionException
 	{
-		if (value instanceof Long || value instanceof Integer)
+		try
+		{
+			// Will throw if value is not of an integral type
+			IntegerType.from(value);
 			this.value = value;
-		else 
-			throw new ResolutionException(this + " is not of a valid flag type. Flags must be ints or longs.");
+		}
+		catch (IllegalArgumentException e)
+		{
+			throw new ResolutionException(value + " is not of a valid flag type", e);
+		}
 	}
 	
 	@Override

--- a/src/test/java/daomephsta/unpick/tests/FlagUninliningTest.java
+++ b/src/test/java/daomephsta/unpick/tests/FlagUninliningTest.java
@@ -137,7 +137,7 @@ public class FlagUninliningTest
 				.add()
 				.build();
 		
-		IntegerType integerType = IntegerType.from(testConstant.getClass());
+		IntegerType integerType = IntegerType.from(testConstant);
 		ConstantUninliner uninliner = new ConstantUninliner(mapper, new ClasspathConstantResolver());
 		
 		MockMethod mockMethod = TestUtils.mockInvokeStatic(Methods.class, 
@@ -164,7 +164,7 @@ public class FlagUninliningTest
 
 	private void testKnownFlagsReturn(Number testConstant, String[] expectedConstantCombination, String[] constantNames)
 	{
-		IntegerType integerType = IntegerType.from(testConstant.getClass());
+		IntegerType integerType = IntegerType.from(testConstant);
 		MockMethod mock = MethodMocker.mock(integerType.getPrimitiveClass(), mv -> 
 		{
 			integerType.appendLiteralPushInsn(mv, testConstant.longValue());
@@ -266,7 +266,7 @@ public class FlagUninliningTest
 				.build();
 
 		ConstantUninliner uninliner = new ConstantUninliner(mapper, new ClasspathConstantResolver());
-		IntegerType integerType = IntegerType.from(testConstant.getClass());
+		IntegerType integerType = IntegerType.from(testConstant);
 
 		MockMethod mockMethod = MethodMocker.mock(void.class, mv -> 
 		{
@@ -293,7 +293,7 @@ public class FlagUninliningTest
 	
 	private void testNegatedFlagsReturn(Number testConstant, String[] expectedConstantCombination, String[] constantNames)
 	{
-		IntegerType integerType = IntegerType.from(testConstant.getClass());
+		IntegerType integerType = IntegerType.from(testConstant);
 		MockMethod mock = MethodMocker.mock(integerType.getPrimitiveClass(), mv -> 
 		{
 			mv.visitFieldInsn(Opcodes.GETSTATIC, "Foo", "bar", integerType.getTypeDescriptor());
@@ -406,7 +406,7 @@ public class FlagUninliningTest
 	
 	private void testUnknownFlagsReturn(Number testConstant)
 	{
-		IntegerType integerType = IntegerType.from(testConstant.getClass());
+		IntegerType integerType = IntegerType.from(testConstant);
 		MockMethod mock = MethodMocker.mock(integerType.getPrimitiveClass(), mv -> 
 		{
 			integerType.appendLiteralPushInsn(mv, testConstant.longValue());

--- a/src/test/java/daomephsta/unpick/tests/FlagUninliningTest.java
+++ b/src/test/java/daomephsta/unpick/tests/FlagUninliningTest.java
@@ -19,7 +19,6 @@ import org.objectweb.asm.tree.MethodNode;
 
 import daomephsta.unpick.api.ConstantUninliner;
 import daomephsta.unpick.api.constantmappers.IConstantMapper;
-import daomephsta.unpick.impl.AbstractInsnNodes;
 import daomephsta.unpick.impl.IntegerType;
 import daomephsta.unpick.impl.constantresolvers.ClasspathConstantResolver;
 import daomephsta.unpick.tests.lib.*;
@@ -29,7 +28,17 @@ public class FlagUninliningTest
 {
 	@SuppressWarnings("unused")
 	private static class Constants
-	{	
+	{
+		public static final byte BYTE_FLAG_BIT_0 = 1 << 0,
+								 BYTE_FLAG_BIT_1 = 1 << 1,
+								 BYTE_FLAG_BIT_2 = 1 << 2,
+								 BYTE_FLAG_BIT_3 = 1 << 3;
+		
+		public static final short SHORT_FLAG_BIT_0 = 1 << 0,
+								  SHORT_FLAG_BIT_1 = 1 << 1,
+								  SHORT_FLAG_BIT_2 = 1 << 2,
+								  SHORT_FLAG_BIT_3 = 1 << 3;
+		
 		public static final int INT_FLAG_BIT_0 = 1 << 0,
 								INT_FLAG_BIT_1 = 1 << 1,
 								INT_FLAG_BIT_2 = 1 << 2,
@@ -52,9 +61,41 @@ public class FlagUninliningTest
 	@SuppressWarnings("unused")
 	private static class Methods
 	{
+		private static void byteConsumer(byte test) {}
+		
+		private static void shortConsumer(short test) {}
+
 		private static void intConsumer(int test) {}
 
 		private static void longConsumer(long test) {}
+	}
+	
+	@ParameterizedTest(name = "{0} -> {1}")
+	@MethodSource("byteFlagsProvider")
+	public void testKnownByteFlagsReturn(Byte testConstant, String[] expectedConstantCombination, String[] constantNames)
+	{
+		testKnownFlagsReturn(testConstant, expectedConstantCombination, constantNames);
+	}
+	
+	@ParameterizedTest(name = "{0} -> {1}")
+	@MethodSource("byteFlagsProvider")
+	public void testKnownByteFlagsParameter(Byte testConstant, String[] expectedConstantCombination, String[] constantNames)
+	{
+		testKnownFlagsParameter(testConstant, expectedConstantCombination, constantNames, "byteConsumer", "(B)V");
+	}
+	
+	@ParameterizedTest(name = "{0} -> {1}")
+	@MethodSource("shortFlagsProvider")
+	public void testKnownShortFlagsReturn(Short testConstant, String[] expectedConstantCombination, String[] constantNames)
+	{
+		testKnownFlagsReturn(testConstant, expectedConstantCombination, constantNames);
+	}
+	
+	@ParameterizedTest(name = "{0} -> {1}")
+	@MethodSource("shortFlagsProvider")
+	public void testKnownShortFlagsParameter(Short testConstant, String[] expectedConstantCombination, String[] constantNames)
+	{
+		testKnownFlagsParameter(testConstant, expectedConstantCombination, constantNames, "shortConsumer", "(S)V");
 	}
 	
 	@ParameterizedTest(name = "{0} -> {1}")
@@ -155,6 +196,34 @@ public class FlagUninliningTest
 					expectedConstantCombination[j], integerType.getTypeDescriptor());
 			ASMAssertions.assertOpcode(mockMethod.instructions.get(j + 1), integerType.getOrOpcode());
 		}
+	}
+
+	@ParameterizedTest(name = "~{0} -> {1}")
+	@MethodSource("byteFlagsProvider")
+	public void testNegatedByteFlagsParameter(Byte testConstant, String[] expectedConstantCombination, String[] constantNames)
+	{
+		testNegatedFlagsParameter(testConstant, expectedConstantCombination, constantNames, "byteConsumer", "(B)V");
+	}
+	
+	@ParameterizedTest(name = "~{0} -> {1}")
+	@MethodSource("byteFlagsProvider")
+	public void testNegatedByteFlagsReturn(Byte testConstant, String[] expectedConstantCombination, String[] constantNames)
+	{
+		testNegatedFlagsReturn(testConstant, expectedConstantCombination, constantNames);
+	}
+
+	@ParameterizedTest(name = "~{0} -> {1}")
+	@MethodSource("shortFlagsProvider")
+	public void testNegatedShortFlagsParameter(Short testConstant, String[] expectedConstantCombination, String[] constantNames)
+	{
+		testNegatedFlagsParameter(testConstant, expectedConstantCombination, constantNames, "shortConsumer", "(B)V");
+	}
+	
+	@ParameterizedTest(name = "~{0} -> {1}")
+	@MethodSource("shortFlagsProvider")
+	public void testNegatedShortFlagsReturn(Short testConstant, String[] expectedConstantCombination, String[] constantNames)
+	{
+		testNegatedFlagsReturn(testConstant, expectedConstantCombination, constantNames);
 	}
 	
 	@ParameterizedTest(name = "~{0} -> {1}")
@@ -260,6 +329,32 @@ public class FlagUninliningTest
 	}
 	
 	@ParameterizedTest(name = "{0} -> {0}")
+	@ValueSource(bytes = {0b0000, 0b100000, 0b01000, 0b11000})
+	public void testUnknownByteFlagsParameter(Byte testConstant)
+	{
+		testUnknownFlagsParameter(testConstant, "byteConsumer", "(B)V");
+	}
+	@ParameterizedTest(name = "{0} -> {0}")
+	@ValueSource(bytes = {0b0000, 0b100000, 0b01000, 0b11000})
+	public void testUnknownByteFlagsReturn(Byte testConstant)
+	{
+		testUnknownFlagsReturn(testConstant);
+	}
+
+	@ParameterizedTest(name = "{0} -> {0}")
+	@ValueSource(shorts = {0b0000, 0b100000, 0b01000, 0b11000})
+	public void testUnknownShortFlagsParameter(Short testConstant)
+	{
+		testUnknownFlagsParameter(testConstant, "shortConsumer", "(S)V");
+	}
+	@ParameterizedTest(name = "{0} -> {0}")
+	@ValueSource(shorts = {0b0000, 0b100000, 0b01000, 0b11000})
+	public void testUnknownShortFlagsReturn(Short testConstant)
+	{
+		testUnknownFlagsReturn(testConstant);
+	}	
+	
+	@ParameterizedTest(name = "{0} -> {0}")
 	@ValueSource(ints = {0b0000, 0b100000, 0b01000, 0b11000})
 	public void testUnknownIntFlagsParameter(Integer testConstant)
 	{
@@ -338,6 +433,30 @@ public class FlagUninliningTest
 		ASMAssertions.assertOpcode(mockInvocation.instructions.get(1), integerType.getReturnOpcode());
 	}
 	
+	private static Stream<Arguments> byteFlagsProvider()
+	{
+		String[] constantNames = {"BYTE_FLAG_BIT_0", "BYTE_FLAG_BIT_1", "BYTE_FLAG_BIT_2", "BYTE_FLAG_BIT_3"};
+		return Stream.of
+		(
+			Arguments.of((byte) 0b0100, new String[] {"BYTE_FLAG_BIT_2"}, constantNames),
+			Arguments.of((byte) 0b1100, new String[] {"BYTE_FLAG_BIT_2", "BYTE_FLAG_BIT_3"}, constantNames),
+			Arguments.of((byte) 0b1010, new String[] {"BYTE_FLAG_BIT_1", "BYTE_FLAG_BIT_3"}, constantNames),
+			Arguments.of((byte) 0b0111, new String[] {"BYTE_FLAG_BIT_0", "BYTE_FLAG_BIT_1", "BYTE_FLAG_BIT_2"}, constantNames)
+		);	
+	}
+	
+	private static Stream<Arguments> shortFlagsProvider()
+	{
+		String[] constantNames = {"SHORT_FLAG_BIT_0", "SHORT_FLAG_BIT_1", "SHORT_FLAG_BIT_2", "SHORT_FLAG_BIT_3"};
+		return Stream.of
+		(
+			Arguments.of((short) 0b0100, new String[] {"SHORT_FLAG_BIT_2"}, constantNames),
+			Arguments.of((short) 0b1100, new String[] {"SHORT_FLAG_BIT_2", "SHORT_FLAG_BIT_3"}, constantNames),
+			Arguments.of((short) 0b1010, new String[] {"SHORT_FLAG_BIT_1", "SHORT_FLAG_BIT_3"}, constantNames),
+			Arguments.of((short) 0b0111, new String[] {"SHORT_FLAG_BIT_0", "SHORT_FLAG_BIT_1", "SHORT_FLAG_BIT_2"}, constantNames)
+		);	
+	}
+	
 	private static Stream<Arguments> intFlagsProvider()
 	{
 		String[] constantNames = {"INT_FLAG_BIT_0", "INT_FLAG_BIT_1", "INT_FLAG_BIT_2", "INT_FLAG_BIT_3"};
@@ -369,7 +488,7 @@ public class FlagUninliningTest
 		int expectedInstructionCount = 3;
 		assertEquals(expectedInstructionCount, mockInvocation.instructions.size(), 
 				String.format("Expected %d instructions, found %d", expectedInstructionCount, mockInvocation.instructions.size()));
-		assertEquals(expectedLiteralValue, AbstractInsnNodes.getLiteralValue(mockInvocation.instructions.get(invocationInsnIndex - 1)));
+		ASMAssertions.assertIsLiteral(mockInvocation.instructions.get(invocationInsnIndex - 1), expectedLiteralValue);
 		ASMAssertions.assertInvokesMethod(mockInvocation.instructions.get(invocationInsnIndex), Methods.class, 
 				constantConsumerName, constantConsumerDescriptor);
 		ASMAssertions.assertOpcode(mockInvocation.instructions.get(invocationInsnIndex + 1), RETURN);


### PR DESCRIPTION
Adds support for short, byte, and char simple constants; plus byte and short flag constants.  
Boolean simple constant support is not included, as parameter names are adequate for giving `true` & `false` meaning.  
Character flag constant support is not included, as chars aren't really meant to be used as integers, and only differ from shorts in that they are unsigned. I'm considering it though, Mojang does plenty of weird stuff.

Supersedes #5.