### PR TITLE
Collect constant resolution errors and fail. Closes #13.

### DIFF
--- a/src/main/java/daomephsta/unpick/api/constantmappers/ConstantMappers.java
+++ b/src/main/java/daomephsta/unpick/api/constantmappers/ConstantMappers.java
@@ -3,6 +3,7 @@ package daomephsta.unpick.api.constantmappers;
 import java.io.InputStream;
 
 import daomephsta.unpick.api.IClassResolver;
+import daomephsta.unpick.api.constantresolvers.IConstantResolver;
 import daomephsta.unpick.constantmappers.datadriven.parser.UnpickSyntaxException;
 import daomephsta.unpick.impl.constantmappers.datadriven.DataDrivenConstantMapper;
 
@@ -11,15 +12,17 @@ import daomephsta.unpick.impl.constantmappers.datadriven.DataDrivenConstantMappe
  * @author Daomephsta
  */
 public class ConstantMappers
-{
+{	
 	/**
-	 * @return a constant mapper that uses the mappings defined by {@code mappingSources}
-	 * @param classResolver a class resolver that can resolve the classes of the target methods
-	 * @param mappingSources streams of text in <a href="https://github.com/Daomephsta/unpick/wiki/Unpick-Format">.unpick format</a>
-	 * @throws UnpickSyntaxException if any of the mapping sources have invalid syntax
-	 */
-	public static IConstantMapper dataDriven(IClassResolver classResolver, InputStream... mappingSources)
-	{
-		return new DataDrivenConstantMapper(classResolver, mappingSources);
-	}
+	 * Creates a data-driven constant mapper. Constants are resolved immediately.
+     * @return a constant mapper that uses the mappings defined by {@code mappingSources}
+     * @param classResolver a class resolver that can resolve the classes of the target methods
+     * @param constantResolver a constant resolver that can resolve the target constant fields
+     * @param mappingSources streams of text in <a href="https://github.com/Daomephsta/unpick/wiki/Unpick-Format">.unpick format</a>
+     * @throws UnpickSyntaxException if any of the mapping sources have invalid syntax
+     */
+    public static IConstantMapper dataDriven(IClassResolver classResolver, IConstantResolver constantResolver, InputStream... mappingSources)
+    {
+        return new DataDrivenConstantMapper(classResolver, constantResolver, mappingSources);
+    }
 }

--- a/src/main/java/daomephsta/unpick/impl/constantmappers/SimpleAbstractConstantMapper.java
+++ b/src/main/java/daomephsta/unpick/impl/constantmappers/SimpleAbstractConstantMapper.java
@@ -10,9 +10,9 @@ import daomephsta.unpick.impl.representations.ReplacementInstructionGenerator.Co
 
 public abstract class SimpleAbstractConstantMapper implements IConstantMapper
 {
-	protected final Map<String, ReplacementInstructionGenerator> constantGroups;
+	protected final Map<String, AbstractConstantGroup<?>> constantGroups;
 	
-	protected SimpleAbstractConstantMapper(Map<String, ReplacementInstructionGenerator> constantGroups)
+	protected SimpleAbstractConstantMapper(Map<String, AbstractConstantGroup<?>> constantGroups)
 	{
 		this.constantGroups = constantGroups;
 	}
@@ -43,7 +43,7 @@ public abstract class SimpleAbstractConstantMapper implements IConstantMapper
 		}
 		if (!constantGroup.canReplace(context))
 		{
-			context.getLogger().log(Level.INFO, "Transformation skipped. Constant group '%s' cannot transform this invocation.", constantGroupID);
+			context.getLogger().log(Level.INFO, "Transformation skipped. Constant group " + constantGroupID + " cannot transform this invocation.");
 			return;
 		}
 		
@@ -69,7 +69,7 @@ public abstract class SimpleAbstractConstantMapper implements IConstantMapper
 		}
 		if (!constantGroup.canReplace(context))
 		{
-			context.getLogger().log(Level.INFO, "Transformation skipped. Constant group '%s' cannot transform this invocation.", constantGroupID);
+			context.getLogger().log(Level.INFO, "Transformation skipped. Constant group " + constantGroupID + " cannot transform this invocation.");
 			return;
 		}
 		

--- a/src/main/java/daomephsta/unpick/impl/constantmappers/datadriven/DataDrivenConstantMapper.java
+++ b/src/main/java/daomephsta/unpick/impl/constantmappers/datadriven/DataDrivenConstantMapper.java
@@ -6,10 +6,12 @@ import java.util.HashMap;
 import java.util.logging.Logger;
 
 import daomephsta.unpick.api.IClassResolver;
+import daomephsta.unpick.api.constantresolvers.IConstantResolver;
 import daomephsta.unpick.constantmappers.datadriven.parser.UnpickSyntaxException;
 import daomephsta.unpick.impl.constantmappers.SimpleAbstractConstantMapper;
 import daomephsta.unpick.impl.constantmappers.datadriven.parser.V1Parser;
 import daomephsta.unpick.impl.constantmappers.datadriven.parser.v2.V2Parser;
+import daomephsta.unpick.impl.representations.AbstractConstantGroup;
 import daomephsta.unpick.impl.representations.TargetMethods;
 
 /**
@@ -21,43 +23,52 @@ public class DataDrivenConstantMapper extends SimpleAbstractConstantMapper
 	private static final Logger LOGGER = Logger.getLogger("unpick");
 	private final TargetMethods targetMethods;
 
-	public DataDrivenConstantMapper(IClassResolver classResolver, InputStream... mappingSources)
+	public DataDrivenConstantMapper(IClassResolver classResolver, IConstantResolver constantResolver, InputStream... mappingSources)
 	{
-		super(new HashMap<>());
-		TargetMethods.Builder targetMethodsBuilder = TargetMethods.builder(classResolver);
-		for (InputStream mappingSource : mappingSources)
-		{
-			try
-			{
-				//Avoid buffering, so that only the version specifier bytes are consumed 
-				byte[] version = new byte [2];
-				mappingSource.read(version);
-				if (version[0] == 'v')
-				{
-					switch (version[1])
-					{
-					case '1':
-						V1Parser.INSTANCE.parse(mappingSource, constantGroups, targetMethodsBuilder);
-						break;
-						
-					case '2':
-						V2Parser.parse(mappingSource, constantGroups, targetMethodsBuilder);
-						break;
-
-					default :
-						throw new UnpickSyntaxException(1, "Unknown version " + (char) version[1]);
-					}
-				}
-				else
-					throw new UnpickSyntaxException(1, "Missing version");
-			} 
-			catch (IOException e)
-			{
-				e.printStackTrace();
-			}
-		}
-		this.targetMethods = targetMethodsBuilder.build();
-		LOGGER.info("Loaded " + targetMethods);
+        super(new HashMap<>());
+        TargetMethods.Builder targetMethodsBuilder = TargetMethods.builder(classResolver);
+        for (InputStream mappingSource : mappingSources)
+        {
+        	try
+        	{
+        		//Avoid buffering, so that only the version specifier bytes are consumed 
+        		byte[] version = new byte [2];
+        		mappingSource.read(version);
+        		if (version[0] == 'v')
+        		{
+        			switch (version[1])
+        			{
+        			case '1':
+        				V1Parser.INSTANCE.parse(mappingSource, constantGroups, targetMethodsBuilder);
+        				break;
+        				
+        			case '2':
+        				V2Parser.parse(mappingSource, constantGroups, targetMethodsBuilder);
+        				break;
+        
+        			default :
+        				throw new UnpickSyntaxException(1, "Unknown version " + (char) version[1]);
+        			}
+        		}
+        		else
+        			throw new UnpickSyntaxException(1, "Missing version");
+        	} 
+        	catch (IOException e)
+        	{
+        		e.printStackTrace();
+        	}
+        }
+        this.targetMethods = targetMethodsBuilder.build();
+        LOGGER.info("Loaded " + targetMethods);
+	    boolean resolved = true;
+	    for (AbstractConstantGroup<?> group : constantGroups.values())
+	    {
+	        group.resolveAllConstants(constantResolver);
+	        if (!group.isResolved())
+	            resolved = false;
+	    }
+	    if (!resolved)
+	        throw new RuntimeException("One or more constants failed to resolve, check the log for details");
 	}
 
 	@Override

--- a/src/main/java/daomephsta/unpick/impl/constantmappers/datadriven/parser/V1Parser.java
+++ b/src/main/java/daomephsta/unpick/impl/constantmappers/datadriven/parser/V1Parser.java
@@ -17,7 +17,7 @@ public enum V1Parser
 	
 	private static final Pattern WHITESPACE_SPLITTER = Pattern.compile("\\s");
 	
-	public void parse(InputStream mappingSource, Map<String, ReplacementInstructionGenerator> constantGroups, TargetMethods.Builder targetMethodsBuilder) throws IOException
+	public void parse(InputStream mappingSource, Map<String, AbstractConstantGroup<?>> constantGroups, TargetMethods.Builder targetMethodsBuilder) throws IOException
 	{
 		try(LineNumberReader reader = new LineNumberReader(new InputStreamReader(mappingSource)))
 		{
@@ -39,7 +39,7 @@ public enum V1Parser
 
 					String group = tokens[1];
 					SimpleConstantDefinition parsedConstant = parseConstantDefinition(tokens, reader.getLineNumber());
-					ReplacementInstructionGenerator constantGroup = constantGroups.get(group);
+					AbstractConstantGroup<?> constantGroup = constantGroups.get(group);
 					if (constantGroup == null)
 					{
 						constantGroups.put(group, (constantGroup = new SimpleConstantGroup(group)));
@@ -58,7 +58,7 @@ public enum V1Parser
 
 					String group = tokens[1];
 					FlagDefinition parsedFlag = parseFlagDefinition(tokens, reader.getLineNumber());
-					ReplacementInstructionGenerator constantGroup = constantGroups.get(group);
+					AbstractConstantGroup<?> constantGroup = constantGroups.get(group);
 					if (constantGroup == null)
 					{
 						constantGroups.put(group, (constantGroup = new FlagConstantGroup(group)));

--- a/src/main/java/daomephsta/unpick/impl/constantmappers/datadriven/parser/v2/V2Parser.java
+++ b/src/main/java/daomephsta/unpick/impl/constantmappers/datadriven/parser/v2/V2Parser.java
@@ -17,17 +17,17 @@ import daomephsta.unpick.impl.representations.TargetMethods.TargetMethodBuilder;
 
 public class V2Parser implements Visitor
 {
-	private final Map<String, ReplacementInstructionGenerator> constantGroups;
+	private final Map<String, AbstractConstantGroup<?>> constantGroups;
 	private final TargetMethods.Builder targetMethodsBuilder;
 	private int lineNumber;
 
-	public V2Parser(Map<String, ReplacementInstructionGenerator> constantGroups, TargetMethods.Builder targetMethodsBuilder)
+	public V2Parser(Map<String, AbstractConstantGroup<?>> constantGroups, TargetMethods.Builder targetMethodsBuilder)
 	{
 		this.constantGroups = constantGroups;
 		this.targetMethodsBuilder = targetMethodsBuilder;
 	}
 
-	public static void parse(InputStream mappingSource, Map<String, ReplacementInstructionGenerator> constantGroups, TargetMethods.Builder targetMethodsBuilder) throws IOException
+	public static void parse(InputStream mappingSource, Map<String, AbstractConstantGroup<?>> constantGroups, TargetMethods.Builder targetMethodsBuilder) throws IOException
 	{
 		try (UnpickV2Reader unpickDefinitions = new UnpickV2Reader(mappingSource))
 		{

--- a/src/main/java/daomephsta/unpick/impl/representations/AbstractConstantGroup.java
+++ b/src/main/java/daomephsta/unpick/impl/representations/AbstractConstantGroup.java
@@ -3,6 +3,7 @@ package daomephsta.unpick.impl.representations;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.logging.Logger;
 
 import daomephsta.unpick.api.constantresolvers.IConstantResolver;
@@ -25,8 +26,9 @@ public abstract class AbstractConstantGroup<T extends AbstractConstantDefinition
 	 */
 	public abstract void add(T constantDefinition);
 	
-	protected final void resolveAllConstants(IConstantResolver constantResolver)
+	public final void resolveAllConstants(IConstantResolver constantResolver)
 	{
+	    List<String> errors = new ArrayList<>();;
 	    for (Iterator<T> iter = unresolvedConstantDefinitions.iterator(); iter.hasNext();)
 	    {
             T definition = iter.next();
@@ -37,12 +39,17 @@ public abstract class AbstractConstantGroup<T extends AbstractConstantDefinition
             } 
             catch (ResolutionException e)
             {
-                LOGGER.severe(e.getMessage());
+                errors.add(e.getMessage());
             }
 	    }
-		if (!unresolvedConstantDefinitions.isEmpty())
-		    throw new RuntimeException("Failed to resolve one or more constants of group " + id);
+	    if (!isResolved())
+	        LOGGER.severe("Resolution failed for the following constants of group " + id + '\n' + String.join("\n", errors));
 	}
+
+    public boolean isResolved()
+    {
+        return unresolvedConstantDefinitions.isEmpty();
+    }
 	
 	protected abstract void acceptResolved(T definition);
 	

--- a/src/main/java/daomephsta/unpick/impl/representations/AbstractConstantGroup.java
+++ b/src/main/java/daomephsta/unpick/impl/representations/AbstractConstantGroup.java
@@ -2,6 +2,7 @@ package daomephsta.unpick.impl.representations;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.logging.Logger;
 
 import daomephsta.unpick.api.constantresolvers.IConstantResolver;
@@ -26,21 +27,21 @@ public abstract class AbstractConstantGroup<T extends AbstractConstantDefinition
 	
 	protected final void resolveAllConstants(IConstantResolver constantResolver)
 	{
+	    for (Iterator<T> iter = unresolvedConstantDefinitions.iterator(); iter.hasNext();)
+	    {
+            T definition = iter.next();
+            try
+            {
+                acceptResolved(definition.resolve(constantResolver));
+                iter.remove();
+            } 
+            catch (ResolutionException e)
+            {
+                LOGGER.severe(e.getMessage());
+            }
+	    }
 		if (!unresolvedConstantDefinitions.isEmpty())
-		{
-			for (T definition : unresolvedConstantDefinitions)
-			{
-				try
-				{
-					acceptResolved(definition.resolve(constantResolver));
-				} 
-				catch (ResolutionException e)
-				{
-					LOGGER.warning(e.getMessage());
-				}
-			}
-			unresolvedConstantDefinitions.clear();
-		}
+		    throw new RuntimeException("Failed to resolve one or more constants of group " + id);
 	}
 	
 	protected abstract void acceptResolved(T definition);

--- a/src/main/java/daomephsta/unpick/impl/representations/FlagConstantGroup.java
+++ b/src/main/java/daomephsta/unpick/impl/representations/FlagConstantGroup.java
@@ -52,8 +52,6 @@ public class FlagConstantGroup extends AbstractConstantGroup<FlagDefinition>
 		Number literalNum = (Number) AbstractInsnNodes.getLiteralValue(context.getArgSeed());
 		IntegerType integerType = IntegerType.from(literalNum);
 
-		resolveAllConstants(context.getConstantResolver());
-
 		long literal = integerType.toUnsignedLong(literalNum);
 		if (literal == 0 || literal == -1)
 		{

--- a/src/main/java/daomephsta/unpick/impl/representations/SimpleConstantGroup.java
+++ b/src/main/java/daomephsta/unpick/impl/representations/SimpleConstantGroup.java
@@ -40,7 +40,6 @@ public class SimpleConstantGroup extends AbstractConstantGroup<SimpleConstantDef
 	@Override
 	public boolean canReplace(Context context)
 	{
-		resolveAllConstants(context.getConstantResolver());
 		return AbstractInsnNodes.hasLiteralValue(context.getArgSeed()) 
 				&& resolvedConstantDefinitions.containsKey(AbstractInsnNodes.getLiteralValue(context.getArgSeed()));
 	}
@@ -48,8 +47,6 @@ public class SimpleConstantGroup extends AbstractConstantGroup<SimpleConstantDef
 	@Override
 	public void generateReplacements(Context context)
 	{
-		resolveAllConstants(context.getConstantResolver());
-		
 		Object literalValue = AbstractInsnNodes.getLiteralValue(context.getArgSeed());
 		SimpleConstantDefinition constantDefinition = resolvedConstantDefinitions.get(literalValue);
 		context.getReplacementSet().addReplacement(context.getArgSeed(), 

--- a/src/test/java/daomephsta/unpick/tests/FlagUninliningTest.java
+++ b/src/test/java/daomephsta/unpick/tests/FlagUninliningTest.java
@@ -26,7 +26,9 @@ import daomephsta.unpick.tests.lib.MethodMocker.MockMethod;
 
 public class FlagUninliningTest
 {
-	@SuppressWarnings("unused")
+	private static final ClasspathConstantResolver CONSTANT_RESOLVER = new ClasspathConstantResolver();
+
+    @SuppressWarnings("unused")
 	private static class Constants
 	{
 		public static final byte BYTE_FLAG_BIT_0 = 1 << 0,
@@ -128,7 +130,7 @@ public class FlagUninliningTest
 
 	private void testKnownFlagsParameter(Number testConstant, String[] expectedConstantCombination, String[] constantNames, String constantConsumerName, String constantConsumerDescriptor)
 	{
-		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER)
+		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER, CONSTANT_RESOLVER)
 				.flagConstantGroup("test")
 					.defineAll(Constants.class, constantNames)
 				.add()
@@ -138,7 +140,7 @@ public class FlagUninliningTest
 				.build();
 		
 		IntegerType integerType = IntegerType.from(testConstant);
-		ConstantUninliner uninliner = new ConstantUninliner(mapper, new ClasspathConstantResolver());
+		ConstantUninliner uninliner = new ConstantUninliner(mapper, CONSTANT_RESOLVER);
 		
 		MockMethod mockMethod = TestUtils.mockInvokeStatic(Methods.class, 
 				constantConsumerName, constantConsumerDescriptor, testConstant);
@@ -172,7 +174,7 @@ public class FlagUninliningTest
 		});
 		MethodNode mockMethod = mock.getMockMethod();
 		
-		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER)
+		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER, CONSTANT_RESOLVER)
 				.flagConstantGroup("test")
 					.defineAll(Constants.class, constantNames)
 				.add()
@@ -181,7 +183,7 @@ public class FlagUninliningTest
 				.add()
 				.build();
 
-		ConstantUninliner uninliner = new ConstantUninliner(mapper, new ClasspathConstantResolver());
+		ConstantUninliner uninliner = new ConstantUninliner(mapper, CONSTANT_RESOLVER);
 		
 		uninliner.transformMethod(mock.getMockClass().name, mockMethod);
 		int minimumInsnCount = 2 * (expectedConstantCombination.length - 1) + 1;
@@ -256,7 +258,7 @@ public class FlagUninliningTest
 	
 	private void testNegatedFlagsParameter(Number testConstant, String[] expectedConstantCombination, String[] constantNames, String consumerName, String consumerDescriptor)
 	{		
-		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER)
+		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER, CONSTANT_RESOLVER)
 				.flagConstantGroup("test")
 				.defineAll(Constants.class, constantNames)
 				.add()
@@ -265,7 +267,7 @@ public class FlagUninliningTest
 				.add()
 				.build();
 
-		ConstantUninliner uninliner = new ConstantUninliner(mapper, new ClasspathConstantResolver());
+		ConstantUninliner uninliner = new ConstantUninliner(mapper, CONSTANT_RESOLVER);
 		IntegerType integerType = IntegerType.from(testConstant);
 
 		MockMethod mockMethod = MethodMocker.mock(void.class, mv -> 
@@ -303,7 +305,7 @@ public class FlagUninliningTest
 		});
 		MethodNode mockMethod = mock.getMockMethod();
 		
-		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER)
+		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER, CONSTANT_RESOLVER)
 				.flagConstantGroup("test")
 					.defineAll(Constants.class, constantNames)
 				.add()
@@ -312,7 +314,7 @@ public class FlagUninliningTest
 				.add()
 				.build();
 
-		ConstantUninliner uninliner = new ConstantUninliner(mapper, new ClasspathConstantResolver());
+		ConstantUninliner uninliner = new ConstantUninliner(mapper, CONSTANT_RESOLVER);
 		
 		uninliner.transformMethod(MethodMocker.CLASS_NAME, mockMethod);
 		ListIterator<AbstractInsnNode> instructions = mockMethod.instructions.iterator(0);
@@ -383,7 +385,7 @@ public class FlagUninliningTest
 	
 	private void testUnknownFlagsParameter(Number constant, String constantConsumerName, String constantConsumerDescriptor)
 	{
-		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER)
+		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER, CONSTANT_RESOLVER)
 				.flagConstantGroup("test")
 				.add()
 				.targetMethod(Methods.class, constantConsumerName, constantConsumerDescriptor)
@@ -391,7 +393,7 @@ public class FlagUninliningTest
 				.add()
 				.build();
 
-		ConstantUninliner uninliner = new ConstantUninliner(mapper, new ClasspathConstantResolver());
+		ConstantUninliner uninliner = new ConstantUninliner(mapper, CONSTANT_RESOLVER);
 
 		MethodNode mockInvocation = TestUtils.mockInvokeStatic(Methods.class, 
 				constantConsumerName, constantConsumerDescriptor, constant).getMockMethod();
@@ -414,7 +416,7 @@ public class FlagUninliningTest
 		});
 		MethodNode mockMethod = mock.getMockMethod();
 		
-		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER)
+		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER, CONSTANT_RESOLVER)
 				.flagConstantGroup("test")
 				.add()
 				.targetMethod(mock.getMockClass().name, mockMethod.name, mockMethod.desc)
@@ -422,7 +424,7 @@ public class FlagUninliningTest
 				.add()
 				.build();
 
-		ConstantUninliner uninliner = new ConstantUninliner(mapper, new ClasspathConstantResolver());
+		ConstantUninliner uninliner = new ConstantUninliner(mapper, CONSTANT_RESOLVER);
 
 		MethodNode mockInvocation = mockMethod;
 		ASMAssertions.assertIsLiteral(mockInvocation.instructions.get(0), testConstant);

--- a/src/test/java/daomephsta/unpick/tests/SimpleConstantUninliningTest.java
+++ b/src/test/java/daomephsta/unpick/tests/SimpleConstantUninliningTest.java
@@ -28,7 +28,9 @@ import daomephsta.unpick.tests.lib.TestUtils;
 
 public class SimpleConstantUninliningTest
 {
-	@SuppressWarnings("unused")
+	private static final ClasspathConstantResolver CONSTANT_RESOLVER = new ClasspathConstantResolver();
+
+    @SuppressWarnings("unused")
 	private static class Methods
 	{
 		private static void byteConsumer(byte test) {}
@@ -433,30 +435,23 @@ public class SimpleConstantUninliningTest
 	@Test
 	public void missingField()
 	{
-		String constantConsumerName = "foo";
-		String constantConsumerDescriptor = "(I)V";
-		Class<?> fieldClass = Constants.class;
-		String fieldName = "DOES_NOT_EXIST";
-		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER)
-				.simpleConstantGroup("test")
-					.define(fieldClass, fieldName)
-				.add()
-				.targetMethod(Methods.class, constantConsumerName, constantConsumerDescriptor)
-					.remapParameter(0, "test")
-				.add()
-				.build();
-
-		ConstantUninliner uninliner = new ConstantUninliner(mapper, new ClasspathConstantResolver());
-		MethodNode mockInvocation = TestUtils.mockInvokeStatic(Methods.class, constantConsumerName, constantConsumerDescriptor, 1)
-				.getMockMethod();
 		Exception ex = assertThrows(RuntimeException.class, () -> 
-		    uninliner.transformMethod(MethodMocker.CLASS_NAME, mockInvocation));
-		assertEquals(ex.getMessage(), "Failed to resolve one or more constants of group test");
+		{
+		    MockConstantMapper.builder(Constants.CLASS_RESOLVER, CONSTANT_RESOLVER)
+    		    .simpleConstantGroup("test")
+    	            .define((Class<?>) Constants.class, "DOES_NOT_EXIST")
+    	        .add()
+    	        .targetMethod(Methods.class, "foo", "(I)V")
+    	            .remapParameter(0, "test")
+    	        .add()
+    	        .build();
+		});
+		assertEquals(ex.getMessage(), "One or more constants failed to resolve, check the log for details");
 	}
 
 	private void testKnownConstantParameter(Object constant, String expectedConstant, String constantConsumerName, String constantConsumerDescriptor)
 	{
-		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER)
+		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER, CONSTANT_RESOLVER)
 				.simpleConstantGroup("test")
 					.define(Constants.class, expectedConstant)
 				.add()
@@ -466,7 +461,7 @@ public class SimpleConstantUninliningTest
 				.build();
 
 		LiteralType literalType = LiteralType.from(constant.getClass());
-		ConstantUninliner uninliner = new ConstantUninliner(mapper, new ClasspathConstantResolver());
+		ConstantUninliner uninliner = new ConstantUninliner(mapper, CONSTANT_RESOLVER);
 		MethodNode mockInvocation = TestUtils.mockInvokeStatic(Methods.class, constantConsumerName, constantConsumerDescriptor, 
 				constant).getMockMethod();
 		int invocationInsnIndex = 1;
@@ -488,7 +483,7 @@ public class SimpleConstantUninliningTest
 		});
 		MethodNode mockMethod = mock.getMockMethod();
 		
-		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER)
+		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER, CONSTANT_RESOLVER)
 				.simpleConstantGroup("test")
 					.define(Constants.class, expectedConstant)
 				.add()
@@ -497,7 +492,7 @@ public class SimpleConstantUninliningTest
 				.add()
 				.build();
 
-		ConstantUninliner uninliner = new ConstantUninliner(mapper, new ClasspathConstantResolver());
+		ConstantUninliner uninliner = new ConstantUninliner(mapper, CONSTANT_RESOLVER);
 
 		int returnInsnIndex = 1;
 		ASMAssertions.assertIsLiteral(mockMethod.instructions.get(returnInsnIndex - 1), constant);
@@ -509,7 +504,7 @@ public class SimpleConstantUninliningTest
 	
 	private void testUnknownConstantParameter(Object constant, String constantConsumerName, String constantConsumerDescriptor)
 	{
-		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER)
+		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER, CONSTANT_RESOLVER)
 				.simpleConstantGroup("test")
 				.add()
 				.targetMethod(Methods.class, constantConsumerName, constantConsumerDescriptor)
@@ -517,7 +512,7 @@ public class SimpleConstantUninliningTest
 				.add()
 				.build();
 
-		ConstantUninliner uninliner = new ConstantUninliner(mapper, new ClasspathConstantResolver());
+		ConstantUninliner uninliner = new ConstantUninliner(mapper, CONSTANT_RESOLVER);
 		MethodNode mockInvocation = TestUtils.mockInvokeStatic(Methods.class, constantConsumerName, constantConsumerDescriptor, 
 				constant).getMockMethod();
 		int invocationInsnIndex = 1;
@@ -538,14 +533,14 @@ public class SimpleConstantUninliningTest
 			literalType.appendReturnInsn(mv);
 		});
 		MethodNode mockMethod = mock.getMockMethod();
-		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER)
+		IConstantMapper mapper = MockConstantMapper.builder(Constants.CLASS_RESOLVER, CONSTANT_RESOLVER)
 				.simpleConstantGroup("test")
 				.add()
 				.targetMethod(mock.getMockClass().name, mockMethod.name, mockMethod.desc)
 					.remapReturn("test")
 				.add()
 				.build();
-		ConstantUninliner uninliner = new ConstantUninliner(mapper, new ClasspathConstantResolver());
+		ConstantUninliner uninliner = new ConstantUninliner(mapper, CONSTANT_RESOLVER);
 
 		int returnInsnIndex = 1;
 		ASMAssertions.assertIsLiteral(mockMethod.instructions.get(returnInsnIndex - 1), constant);

--- a/src/test/java/daomephsta/unpick/tests/SimpleConstantUninliningTest.java
+++ b/src/test/java/daomephsta/unpick/tests/SimpleConstantUninliningTest.java
@@ -1,6 +1,7 @@
 package daomephsta.unpick.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.objectweb.asm.Opcodes.RETURN;
 
 import java.io.IOException;
@@ -448,7 +449,9 @@ public class SimpleConstantUninliningTest
 		ConstantUninliner uninliner = new ConstantUninliner(mapper, new ClasspathConstantResolver());
 		MethodNode mockInvocation = TestUtils.mockInvokeStatic(Methods.class, constantConsumerName, constantConsumerDescriptor, 1)
 				.getMockMethod();
-		uninliner.transformMethod(MethodMocker.CLASS_NAME, mockInvocation);
+		Exception ex = assertThrows(RuntimeException.class, () -> 
+		    uninliner.transformMethod(MethodMocker.CLASS_NAME, mockInvocation));
+		assertEquals(ex.getMessage(), "Failed to resolve one or more constants of group test");
 	}
 
 	private void testKnownConstantParameter(Object constant, String expectedConstant, String constantConsumerName, String constantConsumerDescriptor)

--- a/src/test/java/daomephsta/unpick/tests/lib/MockConstantMapper.java
+++ b/src/test/java/daomephsta/unpick/tests/lib/MockConstantMapper.java
@@ -1,27 +1,47 @@
 package daomephsta.unpick.tests.lib;
 
-import java.util.*;
-import java.util.function.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.objectweb.asm.Type;
 
 import daomephsta.unpick.api.IClassResolver;
+import daomephsta.unpick.api.constantresolvers.IConstantResolver;
 import daomephsta.unpick.impl.constantmappers.SimpleAbstractConstantMapper;
-import daomephsta.unpick.impl.representations.*;
+import daomephsta.unpick.impl.representations.AbstractConstantDefinition;
+import daomephsta.unpick.impl.representations.AbstractConstantGroup;
+import daomephsta.unpick.impl.representations.FlagConstantGroup;
+import daomephsta.unpick.impl.representations.FlagDefinition;
+import daomephsta.unpick.impl.representations.SimpleConstantDefinition;
+import daomephsta.unpick.impl.representations.SimpleConstantGroup;
+import daomephsta.unpick.impl.representations.TargetMethods;
 
 public class MockConstantMapper extends SimpleAbstractConstantMapper
 {
 	private final TargetMethods targetInvocations;
 
-	private MockConstantMapper(Map<String, ReplacementInstructionGenerator> constantGroups, TargetMethods targetInvocations)
+	private MockConstantMapper(Map<String, AbstractConstantGroup<?>> constantGroups, IConstantResolver constantResolver, TargetMethods targetInvocations)
 	{
 		super(constantGroups);
 		this.targetInvocations = targetInvocations;
+        boolean resolved = true;
+        for (AbstractConstantGroup<?> group : constantGroups.values())
+        {
+            group.resolveAllConstants(constantResolver);
+            if (!group.isResolved())
+                resolved = false;
+        }
+        if (!resolved)
+            throw new RuntimeException("One or more constants failed to resolve, check the log for details");
 	}
 
-	public static Builder builder(IClassResolver classResolver)
+	public static Builder builder(IClassResolver classResolver, IConstantResolver constantResolver)
 	{
-		return new Builder(classResolver);
+		return new Builder(classResolver, constantResolver);
 	}
 
 	@Override
@@ -32,12 +52,14 @@ public class MockConstantMapper extends SimpleAbstractConstantMapper
 	
 	public static class Builder
 	{
-		private final Map<String, ReplacementInstructionGenerator> constantGroups = new HashMap<>();
+		private final Map<String, AbstractConstantGroup<?>> constantGroups = new HashMap<>();
 		private final TargetMethods.Builder targetMethodsBuilder;
+        private final IConstantResolver constantResolver;
 		
-		public Builder(IClassResolver classResolver)
+		public Builder(IClassResolver classResolver, IConstantResolver constantResolver)
 		{
-			targetMethodsBuilder = TargetMethods.builder(classResolver);
+			this.targetMethodsBuilder = TargetMethods.builder(classResolver);
+			this.constantResolver = constantResolver;
 		}
 
 		public TargetMethodBuilder targetMethod(Class<?> owner, String name, String descriptor)
@@ -62,7 +84,7 @@ public class MockConstantMapper extends SimpleAbstractConstantMapper
 		
 		public MockConstantMapper build()
 		{
-			return new MockConstantMapper(constantGroups, targetMethodsBuilder.build());
+			return new MockConstantMapper(constantGroups, constantResolver, targetMethodsBuilder.build());
 		}
 	}
 	

--- a/unpick-cli/src/main/java/daomephsta/unpick/cli/Main.java
+++ b/unpick-cli/src/main/java/daomephsta/unpick/cli/Main.java
@@ -4,6 +4,8 @@ import daomephsta.unpick.api.ConstantUninliner;
 import daomephsta.unpick.api.IClassResolver;
 import daomephsta.unpick.api.constantmappers.ConstantMappers;
 import daomephsta.unpick.api.constantresolvers.ConstantResolvers;
+import daomephsta.unpick.api.constantresolvers.IConstantResolver;
+
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.tree.ClassNode;
@@ -58,9 +60,10 @@ public class Main {
              JarClassResolver classResolver = new JarClassResolver(classpath);
              InputStream unpickDefinitionStream = Files.newInputStream(unpickDefinition)
         ) {
+            IConstantResolver constantResolver = ConstantResolvers.bytecodeAnalysis(classResolver);
             ConstantUninliner uninliner = new ConstantUninliner(
-                    ConstantMappers.dataDriven(classResolver, unpickDefinitionStream),
-                    ConstantResolvers.bytecodeAnalysis(classResolver)
+                    ConstantMappers.dataDriven(classResolver, constantResolver, unpickDefinitionStream),
+                    constantResolver
             );
 
             try (JarFile jarFile = new JarFile(inputJar.toFile()); JarOutputStream outputStream = new JarOutputStream(Files.newOutputStream(outputJar))) {


### PR DESCRIPTION
Upgrade constant resolution errors to SEVERE and throw RuntimeException if any occur.
Unfortunately the location means failure occurs after resolution of the first constant group with errors completes. I'm investigating doing better.