### PR TITLE
Update ASM to 9.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,10 @@ allprojects {
     }
 
     dependencies {
-        api 'org.ow2.asm:asm:9.1'
-        api 'org.ow2.asm:asm-tree:9.1'
-        implementation 'org.ow2.asm:asm-commons:9.1'
-        implementation 'org.ow2.asm:asm-util:9.1'
+        api 'org.ow2.asm:asm:9.2'
+        api 'org.ow2.asm:asm-tree:9.2'
+        implementation 'org.ow2.asm:asm-commons:9.2'
+        implementation 'org.ow2.asm:asm-util:9.2'
 
         // Use JUnit test framework
         testImplementation 'org.junit.jupiter:junit-jupiter-api:5.+'


### PR DESCRIPTION
Minecraft 1.18-rc1 fails to unpick using ASM 9.1 with `java.lang.IllegalArgumentException: Unsupported class file major version 62`.

This puts the version in line with [Fabric Loom](https://github.com/FabricMC/fabric-loom/blob/60c908ea1b88e008b776e9f62dc71254aa617e94/build.gradle#L68-L72).