### PR TITLE
Adds a shadow jar for the CLI and makes it fully executable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,11 @@ allprojects {
         implementation 'org.ow2.asm:asm-util:9.1'
 
         // Use JUnit test framework
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.+'
-        testImplementation 'org.junit.jupiter:junit-jupiter-params:5.+'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.+'
-        testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.+'
+        testImplementation platform('org.junit:junit-bom:5.10.1')
+        testImplementation 'org.junit.jupiter:junit-jupiter-api'
+        testImplementation 'org.junit.jupiter:junit-jupiter-params'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     }
 
     test {

--- a/unpick-cli/build.gradle
+++ b/unpick-cli/build.gradle
@@ -1,4 +1,15 @@
+plugins {
+    id 'com.github.johnrengelman.shadow' version '8.1.+'
+    id 'java'
+}
+
 dependencies {
     implementation project(':')
     implementation project(':unpick-format-utils')
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'daomephsta.unpick.cli.Main'
+    }
 }

--- a/unpick-cli/build.gradle
+++ b/unpick-cli/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '8.1.+'
-    id 'java'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 dependencies {
@@ -12,4 +11,8 @@ jar {
     manifest {
         attributes 'Main-Class': 'daomephsta.unpick.cli.Main'
     }
+}
+
+assemble.configure {
+    dependsOn shadowJar
 }


### PR DESCRIPTION
Having unpick as a fully self-contained executable jar makes it more useful as a standalone tool in pipelines like MCP/Neoform :)