### PR TITLE
Implement parsing of doc comments

### DIFF
--- a/unpick-format-utils/src/main/java/daomephsta/unpick/constantmappers/datadriven/parser/v3/UnpickV3Writer.java
+++ b/unpick-format-utils/src/main/java/daomephsta/unpick/constantmappers/datadriven/parser/v3/UnpickV3Writer.java
@@ -42,6 +42,12 @@ public final class UnpickV3Writer extends UnpickV3Visitor {
 	public void visitGroupDefinition(GroupDefinition groupDefinition) {
 		output.append(LINE_SEPARATOR);
 
+		if (groupDefinition.docs() != null) {
+			for (String docLine : groupDefinition.docs().split("\n", -1)) {
+				output.append("#: ").append(docLine).append(LINE_SEPARATOR);
+			}
+		}
+
 		output.append("group ");
 		writeDataType(groupDefinition.dataType());
 

--- a/unpick-format-utils/src/main/java/daomephsta/unpick/constantmappers/datadriven/tree/GroupDefinition.java
+++ b/unpick-format-utils/src/main/java/daomephsta/unpick/constantmappers/datadriven/tree/GroupDefinition.java
@@ -16,7 +16,8 @@ public record GroupDefinition(
 		DataType dataType,
 		@Nullable String name,
 		List<Expression> constants,
-		@Nullable GroupFormat format
+		@Nullable GroupFormat format,
+		@Nullable String docs
 ) {
 	@ApiStatus.Internal
 	public GroupDefinition {
@@ -32,6 +33,8 @@ public record GroupDefinition(
 		private final List<Expression> constants = new ArrayList<>();
 		@Nullable
 		private GroupFormat format;
+		@Nullable
+		private String docs;
 
 		private Builder(DataType dataType, @Nullable String name) {
 			this.dataType = dataType;
@@ -50,7 +53,8 @@ public record GroupDefinition(
 			Builder builder = new Builder(definition.dataType(), definition.name())
 					.scopes(definition.scopes())
 					.constants(definition.constants())
-					.format(definition.format());
+					.format(definition.format())
+					.docs(definition.docs());
 			builder.flags = definition.flags();
 			builder.strict = definition.strict();
 			return builder;
@@ -103,8 +107,13 @@ public record GroupDefinition(
 			return this;
 		}
 
+		public Builder docs(String docs) {
+			this.docs = docs;
+			return this;
+		}
+
 		public GroupDefinition build() {
-			return new GroupDefinition(scopes, flags, strict, dataType, name, constants, format);
+			return new GroupDefinition(scopes, flags, strict, dataType, name, constants, format, docs);
 		}
 	}
 }


### PR DESCRIPTION
Implements parsing of doc comments. See https://github.com/FabricMC/unpick/wiki/Unpick-Format-V3#doc-comments

In the future, this may be used to generate `@MagicConstant` annotations in yarn.

Note that this change is backwards compatible, introducing no new possible syntax errors to unpick files. Additionally, since doc comments are just an extended type comment, which were already implemented, old versions of the unpick V3 parser will correctly ignore doc comments in unpick files.