### PR TITLE
Better lambda support

### DIFF
--- a/src/main/java/daomephsta/unpick/impl/UnpickInterpreter.java
+++ b/src/main/java/daomephsta/unpick/impl/UnpickInterpreter.java
@@ -211,6 +211,12 @@ public class UnpickInterpreter extends Interpreter<UnpickValue> implements Opcod
 	@Override
 	public UnpickValue newParameterValue(boolean isInstanceMethod, int local, Type type) {
 		UnpickValue value = newValue(type);
+
+		if (isInstanceMethod && local == 0) {
+			// don't add a parameter source for the "this" parameter
+			return value;
+		}
+
 		int localIndex = isInstanceMethod ? 1 : 0;
 		int paramIndex = 0;
 		for (Type argument : Type.getArgumentTypes(method.desc)) {

--- a/src/test/java/daomephsta/unpick/tests/TestLambda.java
+++ b/src/test/java/daomephsta/unpick/tests/TestLambda.java
@@ -1,0 +1,59 @@
+package daomephsta.unpick.tests;
+
+import org.junit.jupiter.api.Test;
+
+import daomephsta.unpick.constantmappers.datadriven.tree.DataType;
+import daomephsta.unpick.constantmappers.datadriven.tree.GroupDefinition;
+import daomephsta.unpick.constantmappers.datadriven.tree.TargetMethod;
+import daomephsta.unpick.constantmappers.datadriven.tree.expr.FieldExpression;
+import daomephsta.unpick.tests.lib.TestUtils;
+
+public class TestLambda {
+	@Test
+	public void testGroupOutsideToInsideCapture() {
+		TestUtils.runTest("pkg/TestLambdaOutsideToInsideCapture", data -> {
+			data.visitGroupDefinition(GroupDefinition.Builder.named(DataType.INT, "test")
+					.constant(new FieldExpression("pkg.Constants", "INT_CONST_1", null, true))
+					.build());
+			data.visitTargetMethod(TargetMethod.Builder.builder("pkg.TestLambdaOutsideToInsideCapture", "supplyInt", "()I")
+					.returnGroup("test")
+					.build());
+		});
+	}
+
+	@Test
+	public void testGroupInsideToOutsideCapture() {
+		TestUtils.runTest("pkg/TestLambdaInsideToOutsideCapture", data -> {
+			data.visitGroupDefinition(GroupDefinition.Builder.named(DataType.INT, "test")
+					.constant(new FieldExpression("pkg.Constants", "INT_CONST_1", null, true))
+					.build());
+			data.visitTargetMethod(TargetMethod.Builder.builder("pkg.Constants", "consumeInt", "(I)V")
+					.paramGroup(0, "test")
+					.build());
+		});
+	}
+
+	@Test
+	public void testGroupedFunctionalInterfaceParameter() {
+		TestUtils.runTest("pkg/TestLambdaGroupedFunctionalInterfaceParameter", data -> {
+			data.visitGroupDefinition(GroupDefinition.Builder.named(DataType.INT, "test")
+					.constant(new FieldExpression("pkg.Constants", "INT_CONST_1", null, true))
+					.build());
+			data.visitTargetMethod(TargetMethod.Builder.builder("pkg.TestLambdaGroupedFunctionalInterfaceParameter$I", "run", "(I)V")
+					.paramGroup(0, "test")
+					.build());
+		});
+	}
+
+	@Test
+	public void testGroupedFunctionalInterfaceReturn() {
+		TestUtils.runTest("pkg/TestLambdaGroupedFunctionalInterfaceReturn", data -> {
+			data.visitGroupDefinition(GroupDefinition.Builder.named(DataType.INT, "test")
+					.constant(new FieldExpression("pkg.Constants", "INT_CONST_1", null, true))
+					.build());
+			data.visitTargetMethod(TargetMethod.Builder.builder("pkg.TestLambdaGroupedFunctionalInterfaceReturn$I", "run", "()I")
+					.returnGroup("test")
+					.build());
+		});
+	}
+}

--- a/test-data-expected/src/main/java/pkg/TestLambdaGroupedFunctionalInterfaceParameter.java
+++ b/test-data-expected/src/main/java/pkg/TestLambdaGroupedFunctionalInterfaceParameter.java
@@ -1,0 +1,12 @@
+package pkg;
+
+public class TestLambdaGroupedFunctionalInterfaceParameter {
+	void test() {
+		I itf = i -> System.out.println(i == Constants.INT_CONST_1);
+	}
+
+	@FunctionalInterface
+	interface I {
+		void run(int i);
+	}
+}

--- a/test-data-expected/src/main/java/pkg/TestLambdaGroupedFunctionalInterfaceReturn.java
+++ b/test-data-expected/src/main/java/pkg/TestLambdaGroupedFunctionalInterfaceReturn.java
@@ -1,0 +1,12 @@
+package pkg;
+
+public class TestLambdaGroupedFunctionalInterfaceReturn {
+	void test() {
+		I itf = () -> Constants.INT_CONST_1;
+	}
+
+	@FunctionalInterface
+	interface I {
+		int run();
+	}
+}

--- a/test-data-expected/src/main/java/pkg/TestLambdaInsideToOutsideCapture.java
+++ b/test-data-expected/src/main/java/pkg/TestLambdaInsideToOutsideCapture.java
@@ -1,0 +1,10 @@
+package pkg;
+
+import java.util.function.IntConsumer;
+
+public class TestLambdaInsideToOutsideCapture {
+	private static void test() {
+		int n = Constants.INT_CONST_1;
+		IntConsumer ic = i -> Constants.consumeInt(n);
+	}
+}

--- a/test-data-expected/src/main/java/pkg/TestLambdaOutsideToInsideCapture.java
+++ b/test-data-expected/src/main/java/pkg/TestLambdaOutsideToInsideCapture.java
@@ -1,0 +1,14 @@
+package pkg;
+
+import java.util.function.IntUnaryOperator;
+
+public class TestLambdaOutsideToInsideCapture {
+	private static int supplyInt() {
+		return 0;
+	}
+
+	private static void test() {
+		int n = supplyInt();
+		IntUnaryOperator iuo = i -> n == Constants.INT_CONST_1 ? 0 : 1;
+	}
+}

--- a/test-data/src/main/java/pkg/TestLambdaGroupedFunctionalInterfaceParameter.java
+++ b/test-data/src/main/java/pkg/TestLambdaGroupedFunctionalInterfaceParameter.java
@@ -1,0 +1,12 @@
+package pkg;
+
+public class TestLambdaGroupedFunctionalInterfaceParameter {
+	void test() {
+		I itf = i -> System.out.println(i == 1);
+	}
+
+	@FunctionalInterface
+	interface I {
+		void run(int i);
+	}
+}

--- a/test-data/src/main/java/pkg/TestLambdaGroupedFunctionalInterfaceReturn.java
+++ b/test-data/src/main/java/pkg/TestLambdaGroupedFunctionalInterfaceReturn.java
@@ -1,0 +1,12 @@
+package pkg;
+
+public class TestLambdaGroupedFunctionalInterfaceReturn {
+	void test() {
+		I itf = () -> 1;
+	}
+
+	@FunctionalInterface
+	interface I {
+		int run();
+	}
+}

--- a/test-data/src/main/java/pkg/TestLambdaInsideToOutsideCapture.java
+++ b/test-data/src/main/java/pkg/TestLambdaInsideToOutsideCapture.java
@@ -1,0 +1,10 @@
+package pkg;
+
+import java.util.function.IntConsumer;
+
+public class TestLambdaInsideToOutsideCapture {
+	private static void test() {
+		int n = 1;
+		IntConsumer ic = i -> Constants.consumeInt(n);
+	}
+}

--- a/test-data/src/main/java/pkg/TestLambdaOutsideToInsideCapture.java
+++ b/test-data/src/main/java/pkg/TestLambdaOutsideToInsideCapture.java
@@ -1,0 +1,14 @@
+package pkg;
+
+import java.util.function.IntUnaryOperator;
+
+public class TestLambdaOutsideToInsideCapture {
+	private static int supplyInt() {
+		return 0;
+	}
+
+	private static void test() {
+		int n = supplyInt();
+		IntUnaryOperator iuo = i -> n == 1 ? 0 : 1;
+	}
+}


### PR DESCRIPTION
- Allows constant groups to be propagated into and out of lambdas
- Allows constant groups to be detected in lambdas if specified in the functional interface they implement (the same as already happens in the equivalent case in anonymous classes).

This avoids needing to explicitly constant groups on lambda methods (though this is still possible and takes precedence). It also brings more parity to potential source-code-based implementations of unpick, as lambdas work within the lexical scope of their enclosing method.

## Example usecase

Before:
```java
int i = 19 | (packet.shouldSkipLightingUpdates() ? 128 : 0);
packet.visitUpdates((pos, state) -> this.world.handleBlockUpdate(pos, state, i));
```

After:
```java
int i = Block.NOTIFY_ALL | Block.FORCE_STATE | (packet.shouldSkipLightingUpdates() ? Block.SKIP_LIGHTING_UPDATES : 0);
packet.visitUpdates((pos, state) -> this.world.handleBlockUpdate(pos, state, i)); // i is used inside the lambda
```