### PR TITLE
Support type use annotations for target annotation

### DIFF
--- a/src/main/java/daomephsta/unpick/impl/membercheckers/BytecodeAnalysisMemberChecker.java
+++ b/src/main/java/daomephsta/unpick/impl/membercheckers/BytecodeAnalysisMemberChecker.java
@@ -1,6 +1,7 @@
 package daomephsta.unpick.impl.membercheckers;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -11,6 +12,7 @@ import java.util.concurrent.ConcurrentMap;
 import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
+import org.objectweb.asm.TypeReference;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.FieldNode;
@@ -20,9 +22,12 @@ import org.objectweb.asm.tree.ParameterNode;
 import daomephsta.unpick.api.classresolvers.IClassResolver;
 import daomephsta.unpick.api.classresolvers.IMemberChecker;
 
+import org.objectweb.asm.tree.TypeAnnotationNode;
+
 public class BytecodeAnalysisMemberChecker implements IMemberChecker {
 	@SuppressWarnings("unchecked")
 	private static final List<AnnotationNode>[] EMPTY_ANNOTATION_LIST_ARRAY = new List[0];
+	private static final List<TypeAnnotationNode>[] EMPTY_TYPE_ANNOTATION_LIST_ARRAY = new List[0];
 
 	private final IClassResolver classResolver;
 	private final ConcurrentMap<String, ClassInfo> classInfoCache = new ConcurrentHashMap<>();
@@ -67,13 +72,19 @@ public class BytecodeAnalysisMemberChecker implements IMemberChecker {
 
 			List<MemberInfo> fields = new ArrayList<>();
 			for (FieldNode field : node.fields) {
-				fields.add(MemberInfo.create(field.access, field.name, field.desc).withAnnotations(getAnnotations(field.visibleAnnotations, field.invisibleAnnotations)));
+				fields.add(MemberInfo.create(field.access, field.name, field.desc).withAnnotations(getAnnotations(
+						field.visibleAnnotations, field.invisibleAnnotations, field.visibleTypeAnnotations, field.invisibleTypeAnnotations
+				)));
 			}
 
 			List<MemberInfo> methods = new ArrayList<>();
 			Map<String, List<ParameterInfo>> parameters = new HashMap<>();
 			for (MethodNode method : node.methods) {
-				methods.add(MemberInfo.create(method.access, method.name, method.desc).withAnnotations(getAnnotations(method.visibleAnnotations, method.invisibleAnnotations)));
+				final ExtractedTypeAnnotations extractedTypeAnnotations = extractTypeAnnotations(method);
+
+				methods.add(MemberInfo.create(method.access, method.name, method.desc).withAnnotations(getAnnotations(
+						method.visibleAnnotations, method.invisibleAnnotations, extractedTypeAnnotations.visibleReturnType, extractedTypeAnnotations.invisibleReturnType
+				)));
 
 				List<ParameterInfo> params = new ArrayList<>();
 				parameters.put(method.name + method.desc, params);
@@ -81,9 +92,14 @@ public class BytecodeAnalysisMemberChecker implements IMemberChecker {
 				List<ParameterNode> paramNodes = Objects.requireNonNullElse(method.parameters, List.of());
 				List<AnnotationNode>[] visibleParamAnnotations = Objects.requireNonNullElse(method.visibleParameterAnnotations, EMPTY_ANNOTATION_LIST_ARRAY);
 				List<AnnotationNode>[] invisibleParamAnnotations = Objects.requireNonNullElse(method.invisibleParameterAnnotations, EMPTY_ANNOTATION_LIST_ARRAY);
+
+				final int maxParamAnnotationIndex = Math.max(
+						Math.max(visibleParamAnnotations.length, invisibleParamAnnotations.length),
+						Math.max(extractedTypeAnnotations.visibleMethodParams.length, extractedTypeAnnotations.invisibleMethodParams.length)
+				);
 				int realParamIndex = 0;
 				int nonSyntheticParamIndex = 0;
-				while (nonSyntheticParamIndex < Math.max(visibleParamAnnotations.length, invisibleParamAnnotations.length)) {
+				while (nonSyntheticParamIndex < maxParamAnnotationIndex) {
 					while (realParamIndex < paramNodes.size() && (paramNodes.get(realParamIndex).access & Opcodes.ACC_SYNTHETIC) != 0) {
 						params.add(ParameterInfo.create(0));
 						realParamIndex++;
@@ -93,7 +109,12 @@ public class BytecodeAnalysisMemberChecker implements IMemberChecker {
 					List<AnnotationNode> visibleAnnotations = nonSyntheticParamIndex < visibleParamAnnotations.length ? visibleParamAnnotations[nonSyntheticParamIndex] : null;
 					List<AnnotationNode> invisibleAnnotations = nonSyntheticParamIndex < invisibleParamAnnotations.length ? invisibleParamAnnotations[nonSyntheticParamIndex] : null;
 
-					params.add(ParameterInfo.create(access).withAnnotations(getAnnotations(visibleAnnotations, invisibleAnnotations)));
+					params.add(ParameterInfo.create(access).withAnnotations(getAnnotations(
+							visibleAnnotations,
+							invisibleAnnotations,
+							extractedTypeAnnotations.visibleMethodParams(nonSyntheticParamIndex),
+							extractedTypeAnnotations.invisibleMethodParams(nonSyntheticParamIndex)
+					)));
 
 					nonSyntheticParamIndex++;
 					realParamIndex++;
@@ -104,7 +125,12 @@ public class BytecodeAnalysisMemberChecker implements IMemberChecker {
 		});
 	}
 
-	private static List<String> getAnnotations(@Nullable List<AnnotationNode> visibleAnnotations, @Nullable List<AnnotationNode> invisibleAnnotations) {
+	private static List<String> getAnnotations(
+			@Nullable List<? extends AnnotationNode> visibleAnnotations,
+			@Nullable List<? extends AnnotationNode> invisibleAnnotations,
+			@Nullable List<? extends AnnotationNode> visibleTypeAnnotations,
+			@Nullable List<? extends AnnotationNode> invisibleTypeAnnotations
+	) {
 		List<String> annotations = new ArrayList<>();
 
 		if (visibleAnnotations != null) {
@@ -119,7 +145,68 @@ public class BytecodeAnalysisMemberChecker implements IMemberChecker {
 			}
 		}
 
+		if (visibleTypeAnnotations != null) {
+			for (AnnotationNode annotation : visibleTypeAnnotations) {
+				annotations.add(Type.getType(annotation.desc).getClassName());
+			}
+		}
+
+		if (invisibleTypeAnnotations != null) {
+			for (AnnotationNode annotation : invisibleTypeAnnotations) {
+				annotations.add(Type.getType(annotation.desc).getClassName());
+			}
+		}
+
 		return annotations;
+	}
+
+	record ExtractedTypeAnnotations(
+			List<AnnotationNode>[] visibleMethodParams,
+			List<AnnotationNode>[] invisibleMethodParams,
+			List<AnnotationNode> visibleReturnType,
+			List<AnnotationNode> invisibleReturnType
+	) {
+		public List<AnnotationNode> visibleMethodParams(final int index) {
+			return index > visibleMethodParams.length ? null : visibleMethodParams[index];
+		}
+
+		public List<AnnotationNode> invisibleMethodParams(final int index) {
+			return index > invisibleMethodParams.length ? null : invisibleMethodParams[index];
+		}
+	}
+
+	private static ExtractedTypeAnnotations extractTypeAnnotations(final MethodNode method) {
+		final int parameterCount = Type.getArgumentCount(method.desc);
+		final List<AnnotationNode>[] visibleMethodParams = new List[parameterCount];
+		final List<AnnotationNode>[] invisibleMethodParams = new List[parameterCount];
+		Arrays.setAll(visibleMethodParams, ignored -> new ArrayList<>(0));
+		Arrays.setAll(invisibleMethodParams, ignored -> new ArrayList<>(0));
+
+		final ExtractedTypeAnnotations result = new ExtractedTypeAnnotations(
+			visibleMethodParams,
+			invisibleMethodParams,
+			new ArrayList<>(0),
+			new ArrayList<>(0)
+		);
+		extractTypeAnnotationsInto(method.visibleTypeAnnotations, result.visibleMethodParams, result.visibleReturnType);
+		extractTypeAnnotationsInto(method.invisibleTypeAnnotations, result.invisibleMethodParams, result.invisibleReturnType);
+		return result;
+	}
+
+	private static void extractTypeAnnotationsInto(
+			final @Nullable List<TypeAnnotationNode> annotations,
+			final List<AnnotationNode>[] methodParam,
+			final List<AnnotationNode> returnType
+	) {
+		if (annotations == null) return;
+
+		for (final TypeAnnotationNode annotation : annotations) {
+			final TypeReference typeReference = new TypeReference(annotation.typeRef);
+			switch (typeReference.getSort()) {
+				case TypeReference.METHOD_FORMAL_PARAMETER -> methodParam[typeReference.getFormalParameterIndex()].add(annotation);
+				case TypeReference.METHOD_RETURN -> returnType.add(annotation);
+			}
+		}
 	}
 
 	private record ClassInfo(List<MemberInfo> fields, List<MemberInfo> methods, Map<String, List<ParameterInfo>> parameters) {

--- a/src/main/java/daomephsta/unpick/impl/membercheckers/BytecodeAnalysisMemberChecker.java
+++ b/src/main/java/daomephsta/unpick/impl/membercheckers/BytecodeAnalysisMemberChecker.java
@@ -27,7 +27,6 @@ import org.objectweb.asm.tree.TypeAnnotationNode;
 public class BytecodeAnalysisMemberChecker implements IMemberChecker {
 	@SuppressWarnings("unchecked")
 	private static final List<AnnotationNode>[] EMPTY_ANNOTATION_LIST_ARRAY = new List[0];
-	private static final List<TypeAnnotationNode>[] EMPTY_TYPE_ANNOTATION_LIST_ARRAY = new List[0];
 
 	private final IClassResolver classResolver;
 	private final ConcurrentMap<String, ClassInfo> classInfoCache = new ConcurrentHashMap<>();
@@ -126,10 +125,10 @@ public class BytecodeAnalysisMemberChecker implements IMemberChecker {
 	}
 
 	private static List<String> getAnnotations(
-			@Nullable List<? extends AnnotationNode> visibleAnnotations,
-			@Nullable List<? extends AnnotationNode> invisibleAnnotations,
-			@Nullable List<? extends AnnotationNode> visibleTypeAnnotations,
-			@Nullable List<? extends AnnotationNode> invisibleTypeAnnotations
+			@Nullable List<AnnotationNode> visibleAnnotations,
+			@Nullable List<AnnotationNode> invisibleAnnotations,
+			@Nullable List<TypeAnnotationNode> visibleTypeAnnotations,
+			@Nullable List<TypeAnnotationNode> invisibleTypeAnnotations
 	) {
 		List<String> annotations = new ArrayList<>();
 
@@ -146,14 +145,14 @@ public class BytecodeAnalysisMemberChecker implements IMemberChecker {
 		}
 
 		if (visibleTypeAnnotations != null) {
-			for (AnnotationNode annotation : visibleTypeAnnotations) {
-				annotations.add(Type.getType(annotation.desc).getClassName());
+			for (TypeAnnotationNode annotation : visibleTypeAnnotations) {
+				if (annotation.typePath == null || annotation.typePath.getLength() == 0) annotations.add(Type.getType(annotation.desc).getClassName());
 			}
 		}
 
 		if (invisibleTypeAnnotations != null) {
-			for (AnnotationNode annotation : invisibleTypeAnnotations) {
-				annotations.add(Type.getType(annotation.desc).getClassName());
+			for (TypeAnnotationNode annotation : invisibleTypeAnnotations) {
+				if (annotation.typePath == null || annotation.typePath.getLength() == 0) annotations.add(Type.getType(annotation.desc).getClassName());
 			}
 		}
 

--- a/src/main/java/daomephsta/unpick/impl/membercheckers/BytecodeAnalysisMemberChecker.java
+++ b/src/main/java/daomephsta/unpick/impl/membercheckers/BytecodeAnalysisMemberChecker.java
@@ -167,11 +167,11 @@ public class BytecodeAnalysisMemberChecker implements IMemberChecker {
 			List<AnnotationNode> invisibleReturnType
 	) {
 		public List<AnnotationNode> visibleMethodParams(final int index) {
-			return index > visibleMethodParams.length ? null : visibleMethodParams[index];
+			return index < visibleMethodParams.length ? visibleMethodParams[index] : null;
 		}
 
 		public List<AnnotationNode> invisibleMethodParams(final int index) {
-			return index > invisibleMethodParams.length ? null : invisibleMethodParams[index];
+			return index < invisibleMethodParams.length ? invisibleMethodParams[index] : null;
 		}
 	}
 

--- a/src/main/java/daomephsta/unpick/impl/membercheckers/BytecodeAnalysisMemberChecker.java
+++ b/src/main/java/daomephsta/unpick/impl/membercheckers/BytecodeAnalysisMemberChecker.java
@@ -18,11 +18,10 @@ import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.ParameterNode;
+import org.objectweb.asm.tree.TypeAnnotationNode;
 
 import daomephsta.unpick.api.classresolvers.IClassResolver;
 import daomephsta.unpick.api.classresolvers.IMemberChecker;
-
-import org.objectweb.asm.tree.TypeAnnotationNode;
 
 public class BytecodeAnalysisMemberChecker implements IMemberChecker {
 	@SuppressWarnings("unchecked")
@@ -160,32 +159,32 @@ public class BytecodeAnalysisMemberChecker implements IMemberChecker {
 	}
 
 	record ExtractedTypeAnnotations(
-			List<AnnotationNode>[] visibleMethodParams,
-			List<AnnotationNode>[] invisibleMethodParams,
-			List<AnnotationNode> visibleReturnType,
-			List<AnnotationNode> invisibleReturnType
+			List<TypeAnnotationNode>[] visibleMethodParams,
+			List<TypeAnnotationNode>[] invisibleMethodParams,
+			List<TypeAnnotationNode> visibleReturnType,
+			List<TypeAnnotationNode> invisibleReturnType
 	) {
-		public List<AnnotationNode> visibleMethodParams(final int index) {
+		public List<TypeAnnotationNode> visibleMethodParams(final int index) {
 			return index < visibleMethodParams.length ? visibleMethodParams[index] : null;
 		}
 
-		public List<AnnotationNode> invisibleMethodParams(final int index) {
+		public List<TypeAnnotationNode> invisibleMethodParams(final int index) {
 			return index < invisibleMethodParams.length ? invisibleMethodParams[index] : null;
 		}
 	}
 
 	private static ExtractedTypeAnnotations extractTypeAnnotations(final MethodNode method) {
 		final int parameterCount = Type.getArgumentCount(method.desc);
-		final List<AnnotationNode>[] visibleMethodParams = new List[parameterCount];
-		final List<AnnotationNode>[] invisibleMethodParams = new List[parameterCount];
+		final List<TypeAnnotationNode>[] visibleMethodParams = new List[parameterCount];
+		final List<TypeAnnotationNode>[] invisibleMethodParams = new List[parameterCount];
 		Arrays.setAll(visibleMethodParams, ignored -> new ArrayList<>(0));
 		Arrays.setAll(invisibleMethodParams, ignored -> new ArrayList<>(0));
 
 		final ExtractedTypeAnnotations result = new ExtractedTypeAnnotations(
-			visibleMethodParams,
-			invisibleMethodParams,
-			new ArrayList<>(0),
-			new ArrayList<>(0)
+				visibleMethodParams,
+				invisibleMethodParams,
+				new ArrayList<>(0),
+				new ArrayList<>(0)
 		);
 		extractTypeAnnotationsInto(method.visibleTypeAnnotations, result.visibleMethodParams, result.visibleReturnType);
 		extractTypeAnnotationsInto(method.invisibleTypeAnnotations, result.invisibleMethodParams, result.invisibleReturnType);
@@ -194,8 +193,8 @@ public class BytecodeAnalysisMemberChecker implements IMemberChecker {
 
 	private static void extractTypeAnnotationsInto(
 			final @Nullable List<TypeAnnotationNode> annotations,
-			final List<AnnotationNode>[] methodParam,
-			final List<AnnotationNode> returnType
+			final List<TypeAnnotationNode>[] methodParam,
+			final List<TypeAnnotationNode> returnType
 	) {
 		if (annotations == null) return;
 

--- a/src/main/java/daomephsta/unpick/impl/membercheckers/ClasspathMemberChecker.java
+++ b/src/main/java/daomephsta/unpick/impl/membercheckers/ClasspathMemberChecker.java
@@ -115,7 +115,7 @@ public class ClasspathMemberChecker implements IMemberChecker {
 				field.getModifiers(),
 				field.getName(),
 				Type.getDescriptor(field.getType())
-		).withAnnotations(convertAnnotations(field.getAnnotations()));
+		).withAnnotations(convertAnnotations(field.getAnnotatedType().getAnnotations(), field.getAnnotations()));
 	}
 
 	private static MemberInfo methodToMemberInfo(Method method) {
@@ -123,7 +123,7 @@ public class ClasspathMemberChecker implements IMemberChecker {
 				method.getModifiers(),
 				method.getName(),
 				Type.getMethodDescriptor(method)
-		).withAnnotations(convertAnnotations(method.getAnnotations()));
+		).withAnnotations(convertAnnotations(method.getAnnotatedReturnType().getAnnotations(), method.getAnnotations()));
 	}
 
 	private static MemberInfo constructorToMemberInfo(Constructor<?> constructor) {
@@ -131,15 +131,18 @@ public class ClasspathMemberChecker implements IMemberChecker {
 				constructor.getModifiers(),
 				"<init>",
 				Type.getConstructorDescriptor(constructor)
-		).withAnnotations(convertAnnotations(constructor.getAnnotations()));
+		).withAnnotations(convertAnnotations(constructor.getAnnotatedReturnType().getAnnotations(), constructor.getAnnotations()));
 	}
 
 	private static ParameterInfo parameterToParameterInfo(Parameter parameter) {
 		return ParameterInfo.create(parameter.getModifiers())
-				.withAnnotations(convertAnnotations(parameter.getAnnotations()));
+				.withAnnotations(convertAnnotations(parameter.getAnnotatedType().getAnnotations(), parameter.getAnnotations()));
 	}
 
-	private static List<String> convertAnnotations(Annotation[] annotations) {
-		return Arrays.stream(annotations).map(ann -> ann.annotationType().getName().replace('.', '/')).toList();
+	private static List<String> convertAnnotations(Annotation[] typeAnnotations, Annotation[] annotations) {
+		return Stream.concat(
+				Arrays.stream(typeAnnotations),
+				Arrays.stream(annotations)
+		).map(ann -> ann.annotationType().getName().replace('.', '/')).toList();
 	}
 }

--- a/src/test/java/daomephsta/unpick/tests/TestTargetAnnotations.java
+++ b/src/test/java/daomephsta/unpick/tests/TestTargetAnnotations.java
@@ -18,4 +18,14 @@ public class TestTargetAnnotations {
 			data.visitTargetAnnotation(new TargetAnnotation("pkg.TestAnnotation", "g"));
 		});
 	}
+
+	@Test
+	public void testTargetTypeAnnotations() {
+		TestUtils.runTest("pkg/TestTargetTypeAnnotations", data -> {
+			data.visitGroupDefinition(GroupDefinition.Builder.named(DataType.INT, "g")
+					.constant(new FieldExpression("pkg.Constants", "INT_CONST_1", null, true))
+					.build());
+			data.visitTargetAnnotation(new TargetAnnotation("pkg.TestTypeAnnotation", "g"));
+		});
+	}
 }

--- a/test-data-expected/src/main/java/pkg/TestTargetTypeAnnotations.java
+++ b/test-data-expected/src/main/java/pkg/TestTargetTypeAnnotations.java
@@ -1,0 +1,27 @@
+package pkg;
+
+public class TestTargetTypeAnnotations {
+	@TestTypeAnnotation
+	int field;
+
+	boolean testField() {
+		return field == Constants.INT_CONST_1;
+	}
+
+	@TestTypeAnnotation
+	int testReturn() {
+		return Constants.INT_CONST_1;
+	}
+
+	boolean testParam(@TestTypeAnnotation int i) {
+		return i == Constants.INT_CONST_1;
+	}
+
+	boolean testReturnRef() {
+		return testReturn() == Constants.INT_CONST_1;
+	}
+
+	void testParamRef() {
+		testParam(Constants.INT_CONST_1);
+	}
+}

--- a/test-data-expected/src/main/java/pkg/TestTypeAnnotation.java
+++ b/test-data-expected/src/main/java/pkg/TestTypeAnnotation.java
@@ -1,0 +1,11 @@
+package pkg;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE_USE)
+public @interface TestTypeAnnotation {
+}

--- a/test-data/src/main/java/pkg/TestTargetTypeAnnotations.java
+++ b/test-data/src/main/java/pkg/TestTargetTypeAnnotations.java
@@ -1,0 +1,27 @@
+package pkg;
+
+public class TestTargetTypeAnnotations {
+	@TestTypeAnnotation
+	int field;
+
+	boolean testField() {
+		return field == 1;
+	}
+
+	@TestTypeAnnotation
+	int testReturn() {
+		return 1;
+	}
+
+	boolean testParam(@TestTypeAnnotation int i) {
+		return i == 1;
+	}
+
+	boolean testReturnRef() {
+		return testReturn() == 1;
+	}
+
+	void testParamRef() {
+		testParam(1);
+	}
+}

--- a/test-data/src/main/java/pkg/TestTypeAnnotation.java
+++ b/test-data/src/main/java/pkg/TestTypeAnnotation.java
@@ -1,0 +1,11 @@
+package pkg;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE_USE)
+public @interface TestTypeAnnotation {
+}


### PR DESCRIPTION
The previous member checker implementations were both limited to non type annotations.

Resolves: https://github.com/FabricMC/unpick/issues/46